### PR TITLE
RandomProvider.getRandom argument fix to cover range Character.MIN - MAX_VALUE

### DIFF
--- a/src/main/java/com/facebook/genAlgo/gene/Gene.java
+++ b/src/main/java/com/facebook/genAlgo/gene/Gene.java
@@ -14,7 +14,7 @@ public class Gene {
     }
 
     private void generateValue() {
-        value = (char) randomProvider.getRandom(1000);
+        value = (char) randomProvider.getRandom(Character.MAX_VALUE + 1);
     }
 
     public char getValue() {


### PR DESCRIPTION
…, since we want to have numbers from range MIN_VALUE - MAX_VALUE and getRandom() upper bound is exclusive.